### PR TITLE
Integrate dashboard with TDP project

### DIFF
--- a/apps/frontend/src/features/tdp-bm/bm-main.tsx
+++ b/apps/frontend/src/features/tdp-bm/bm-main.tsx
@@ -1,13 +1,76 @@
-import { useState } from 'react'
+import React, { useEffect, useState } from "react";
+import { fetchNotebook } from "./utils/utils";
+interface NotebookCellOutput {
+  data?: {
+      ["image/png"]?: string; 
+  };
+}
 
-const BmMain = () => {
+interface NotebookCell {
+  cell_type: string;
+  outputs?: NotebookCellOutput[];
+}
+
+interface NotebookJson {
+  cells: NotebookCell[];
+}
+
+const BmMain: React.FC = () => {
+  const [graphs, setGraphs] = useState<string[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+      async function loadImages() {
+          try {
+            const notebook: NotebookJson = await fetchNotebook();
+            const imgList: string[] = [];
+        
+            notebook.cells.forEach((cell: NotebookCell) => {
+                if (cell.cell_type === "code" && cell.outputs) {
+                    cell.outputs.forEach((output: NotebookCellOutput) => {
+                        if (output.data && output.data["image/png"]) {
+                            const imageData = `data:image/png;base64,${output.data["image/png"]}`;
+                            imgList.push(imageData);
+                        }
+                    });
+                }
+            });
+        
+            setGraphs(imgList);
+        } catch (error) {
+            console.error("Error fetching notebook images:", error);
+        }
+       finally {
+              setLoading(false);
+          }
+      }
+
+      loadImages();
+  }, []);
 
   return (
-    <>
-        <h1>Bechmarking Module</h1>
+      <div className="p-8">
+          <h1 className="text-2xl font-bold text-[#5C5C5D] mb-6">Benchmarking Module</h1>
 
-    </>
-  )
-}
+          {loading ? (
+              <p className="text-center text-gray-500">Loading graphs...</p>
+          ) : graphs.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+                  {graphs.map((graph, index) => (
+                      <div key={index} className="bg-white p-6 shadow-lg rounded-lg flex justify-center">
+                          <img
+                              src={graph}
+                              alt={`Graph ${index + 1}`}
+                              className="w-full max-h-[500px] object-contain rounded-lg"
+                          />
+                      </div>
+                  ))}
+              </div>
+          ) : (
+              <p className="text-center text-gray-500">No graphs found in the notebook.</p>
+          )}
+      </div>
+  );
+};
 
 export default BmMain

--- a/apps/frontend/src/features/tdp-bm/utils/utils.ts
+++ b/apps/frontend/src/features/tdp-bm/utils/utils.ts
@@ -1,0 +1,10 @@
+// iPynb notebook to be fetched from Github
+export const notebookUrl = "https://raw.githubusercontent.com/pvlefang/TDP-BM-Tender-Discovery-Platform---Benchmarking-/main/Copy_of_Government_Tender_Bids_Analysis.ipynb";
+
+export async function fetchNotebook() {
+    const response = await fetch(notebookUrl);
+    if (!response.ok) {
+        throw new Error("Failed to fetch notebook");
+    }
+    return response.json();
+}


### PR DESCRIPTION
Integrated dashboard with TDP project ([as per this request](https://app.clickup.com/9013520630/chat/r/6-901307348361-8/t/80130003399619))

Dashboard dynamically loads and displays graphs from a Jupyter Notebook hosted on Github
- Fetched via `fetchNotebook()` from a raw GitHub URL
- Parses contents of notebook's cells and extracts `image/png` outputs
- Images rendered as responsive cards in grid layout

The current URL that it fetches from is the [Government Tender Bids Analysis](https://github.com/pvlefang/TDP-BM-Tender-Discovery-Platform---Benchmarking-/blob/main/Copy_of_Government_Tender_Bids_Analysis.ipynb); updating the Notebook file will also update the UI output (dynamic)
