### PR TITLE
Add keyword-based capability assessment logic to backend

### DIFF
--- a/apps/rfp_backend/rfp_backend/main.py
+++ b/apps/rfp_backend/rfp_backend/main.py
@@ -18,16 +18,44 @@ layout = spaCyLayout(nlp)
 def upload_pdf():
     file = request.files['pdf']
     pdf_data = file.read()
+
+    # Extract text from PDF
     doc = layout(pdf_data)
-    analyzed_doc = nlp(doc.text)
+    full_text = doc.text.lower()  # Convert to lowercase for easier keyword matching
+
+    # Run NLP for additional analysis (optional but kept for consistency)
+    analyzed_doc = nlp(full_text)
     sentences_with_dates = [sent.text for sent in analyzed_doc.sents if any(ent.label_ == "DATE" for ent in sent.ents)]
     sentences_with_money = [sent.text for sent in analyzed_doc.sents if any(ent.label_ == "MONEY" for ent in sent.ents)]
     entities = [(ent.text, ent.label_) for ent in analyzed_doc.ents]
+
+    # Capability keyword matching logic
+    KEYWORDS = [
+        "tech services",
+        "technical support",
+        "maintenance",
+        "web design",
+        "software development",
+        "IT infrastructure",
+        "cybersecurity",
+        "cloud solutions",
+        "data analytics",
+        "mobile app development"
+    ]
+
+    verdict = "No, we are not capable of this tender."
+    for keyword in KEYWORDS:
+        if keyword.lower() in full_text:
+            verdict = "Yes, we are capable of doing this tender."
+            break
+
     return jsonify({
         "sentences_with_dates": sentences_with_dates,
         "sentences_with_money": sentences_with_money,
-        "entities": entities
+        "entities": entities,
+        "capability_verdict": verdict  # <-- NEW FIELD added
     })
+
 @app.route('/', methods=['GET'])
 def home():
     return "hello!"


### PR DESCRIPTION
Summary:
Added keyword-based logic to the /analyze_pdf endpoint in main.py to determine if an RFP matches our offered services.

Changes:

Scans PDF text for predefined service keywords (e.g., "web design", "maintenance")

Returns a capability_verdict:

✅ "Yes, we are capable of doing this tender."

❌ "No, we are not capable of this tender."

Impact:
Enables automated tender qualification based on document content.