### PR TITLE
feat(article): create ArticleMain and ArticlePage components (ArticleMain_component_for_the_page_86a7hprnx)

### DIFF
--- a/apps/frontend/src/app.tsx
+++ b/apps/frontend/src/app.tsx
@@ -3,23 +3,30 @@ import { useEffect, useState } from "react";
 import AppRoutes from "./routes/AppRoutes";
 import { useAuth } from "./auth/components/AuthContext";
 import { getaccountAPI } from "./api/api";
+// article import
+import ArticleMain from './features/tdp-kb/components/ArticleMain';
+
 
 // ADD:
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
+
 function App() {
   const { auth, setAuth } = useAuth();
   const [appLoading, setAppLoading] = useState<boolean>(true);
+
 
   useEffect(() => {
     const fetchUser = async () => {
       const token = localStorage.getItem("access_token");
 
+
       if (!token) {
         setAppLoading(false);
         return; // No token means no authentication, stop execution
       }
+
 
       try {
         const response = await getaccountAPI(); // Fetch user data
@@ -38,16 +45,45 @@ function App() {
       }
     };
 
+
     fetchUser();
   }, [setAuth]);
+  const articleData = {
+    title: 'Sample Article Title',
+    datePosted: 'March 29, 2025',
+    category: 'Tech',
+    content: '<p>This is a sample article with some <strong>content</strong>!</p>',
+    relatedArticles: [
+      { title: 'Related Article 1', slug: 'related-article-1' },
+      { title: 'Related Article 2', slug: 'related-article-2' },
+    ],
+  };
+
 
   return (
     <>
       <AppRoutes />
       {/* Add ToastContainer so toast notifications can appear */}
       <ToastContainer />
+
+
+
+
+      <div>
+      <ArticleMain
+        title={articleData.title}
+        datePosted={articleData.datePosted}
+        category={articleData.category}
+        content={articleData.content}
+        relatedArticles={articleData.relatedArticles}
+      />
+    </div>
     </>
+
+
+   
   );
 }
+
 
 export default App;

--- a/apps/frontend/src/features/tdp-kb/components/ArticleMain.tsx
+++ b/apps/frontend/src/features/tdp-kb/components/ArticleMain.tsx
@@ -1,0 +1,47 @@
+// tdp-kb/components/ArticleMain.tsx
+import React from 'react';
+
+
+interface ArticleMainProps {
+  title: string;
+  datePosted: string;
+  category: string;
+  content: string;
+  relatedArticles: { title: string; slug: string }[];
+}
+
+
+const ArticleMain: React.FC<ArticleMainProps> = ({ title, datePosted, category, content, relatedArticles }) => {
+  return (
+    <div style={{ padding: '20px', maxWidth: '900px', margin: '0 auto' }}>
+      <header style={{ textAlign: 'center' }}>
+        <h1>{title}</h1>
+        <p style={{ fontSize: '14px', color: '#777' }}>
+          <span>{datePosted}</span> | <span>{category}</span>
+        </p>
+      </header>
+
+
+      <main style={{ marginTop: '20px' }}>
+        <div style={{ fontSize: '16px', lineHeight: '1.6' }} dangerouslySetInnerHTML={{ __html: content }} />
+      </main>
+
+
+      <section style={{ marginTop: '40px' }}>
+        <h2>Related Articles</h2>
+        <ul style={{ padding: 0, listStyleType: 'none' }}>
+          {relatedArticles.map((article) => (
+            <li key={article.slug} style={{ margin: '5px 0' }}>
+              <a href={`/article/${article.slug}`} style={{ color: '#0070f3', textDecoration: 'none' }}>
+                {article.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+
+export default ArticleMain;

--- a/apps/frontend/src/features/tdp-kb/pages/article-page.tsx
+++ b/apps/frontend/src/features/tdp-kb/pages/article-page.tsx
@@ -1,0 +1,30 @@
+// tdp-kb/pages/article-page.tsx
+import React from 'react';
+import ArticleMain from '../components/ArticleMain';
+
+
+interface ArticlePageProps {
+  title: string;
+  datePosted: string;
+  category: string;
+  content: string;
+  relatedArticles: { title: string; slug: string }[];
+}
+
+
+const ArticlePage: React.FC<ArticlePageProps> = ({ title, datePosted, category, content, relatedArticles }) => {
+  return (
+    <div className="article-page">
+      <ArticleMain
+        title={title}
+        datePosted={datePosted}
+        category={category}
+        content={content}
+        relatedArticles={relatedArticles}
+      />
+    </div>
+  );
+};
+
+
+export default ArticlePage;


### PR DESCRIPTION
As an admin,  
I want to display article details with a reusable ArticleMain component  
So that users can easily view the article content and explore related articles

Tasks:
- Created the ArticleMain component to render article title, publication date, category, content, and related articles.
- Implemented dangerouslySetInnerHTML to render HTML content inside the article body.
- Added basic styling for layout and presentation of the ArticleMain component.
- Created the ArticlePage component to serve as a container for ArticleMain, passing necessary props.
- Ensured the components work together for displaying article data correctly.

Technical Implementation:
- The ArticleMain component is reusable and accepts props such as title, datePosted, category, content, and relatedArticles.
- The ArticlePage component imports ArticleMain and handles the data rendering by passing relevant props.
- Introduced a consistent component structure for article pages, ensuring better maintainability and scalability across the app.
- Basic styling has been applied for layout and presentation, ensuring clarity in how article data is displayed.

Next Steps:
- Add further styling and ensure responsiveness for mobile devices.
- Implement tests for both ArticleMain and ArticlePage components.

Output Example at bottom of app:
![image](https://github.com/user-attachments/assets/75cb5d98-689a-4b32-8d1f-f647572a726f)
